### PR TITLE
Reenable support for bigStepForward and bigStepBack remote commands,

### DIFF
--- a/plex/Remote/PlexRemotePlaybackHandler.cpp
+++ b/plex/Remote/PlexRemotePlaybackHandler.cpp
@@ -15,7 +15,9 @@
 CPlexRemoteResponse CPlexRemotePlaybackHandler::handle(const CStdString &url, const ArgMap &arguments)
 {
   if (url.Equals("/player/playback/stepForward") ||
-           url.Equals("/player/playback/stepBack"))
+           url.Equals("/player/playback/stepBack") ||
+           url.Equals("/player/playback/bigStepForward") ||
+           url.Equals("/player/playback/bigStepBack"))
     return stepFunction(url, arguments);
   else if (url.Equals("/player/playback/skipNext"))
     return skipNext(arguments);


### PR DESCRIPTION
which were supported in the past, and still are supported by CPlexRemotePlaybackHandler::stepFunction
but they are not caught within CPlexRemotePlaybackHandler::handle
