### PR TITLE
Fix token corruption causing major client slowdown

### DIFF
--- a/plex/Client/PlexServer.cpp
+++ b/plex/Client/PlexServer.cpp
@@ -441,15 +441,13 @@ CURL CPlexServer::BuildURL(const CStdString &path, const CStdString &options) co
     CStdString token;
     BOOST_FOREACH(CPlexConnectionPtr conn, m_connections)
     {
-      if (!conn->GetAccessToken().empty())
+      if (!conn->GetAccessToken().IsEmpty())
       {
         token = conn->GetAccessToken();
+        url.SetOption(connection->GetAccessTokenParameter(), token);
         break;
       }
     }
-
-    if (!token.empty())
-      url.SetOption(connection->GetAccessTokenParameter(), token);
   }
   return url;
 }
@@ -459,7 +457,7 @@ bool CPlexServer::HasAuthToken() const
 {
   BOOST_FOREACH(CPlexConnectionPtr conn, m_connections)
   {
-    if (!conn->GetAccessToken().empty())
+    if (!conn->GetAccessToken().IsEmpty())
       return true;
   }
   return false;
@@ -470,7 +468,7 @@ string CPlexServer::GetAnyToken() const
 {
   BOOST_FOREACH(CPlexConnectionPtr conn, m_connections)
   {
-    if (!conn->GetAccessToken().empty())
+    if (!conn->GetAccessToken().IsEmpty())
       return conn->GetAccessToken();
   }
   return string();

--- a/plex/Utility/PlexAES.cpp
+++ b/plex/Utility/PlexAES.cpp
@@ -10,13 +10,14 @@ std::vector<std::string> CPlexAES::chunkData(const std::string& data)
 {
   std::vector<std::string> chunks;
   int i = 0;
+
   while (true)
   {
     std::string chunk = data.substr(i, 16);
     chunks.push_back(chunk);
     if (chunk.length() < 16)
       break;
-    
+
     i += 16;
   }
 
@@ -26,21 +27,23 @@ std::vector<std::string> CPlexAES::chunkData(const std::string& data)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 std::string CPlexAES::encrypt(const std::string &data)
 {
-  std::vector<std::string> chunks = chunkData(data);
-  
+  if (data.empty()) {
+    return "";
+  }
+
+  unsigned char block[16], buffer[16];
   std::string outData;
-  BOOST_FOREACH(const std::string& chunk, chunks)
+
+  BOOST_FOREACH(const std::string& chunk, chunkData(data))
   {
-    unsigned char buffer[16];
-    memset(buffer, '\0', 16);
-    
-    if (aes_encrypt((const unsigned char*)chunk.c_str(), buffer, &m_encryptCtx) == EXIT_FAILURE)
+    strncpy((char *)&block[0], chunk.c_str(), chunk.length());
+    if (aes_encrypt(block, buffer, &m_encryptCtx) == EXIT_FAILURE)
     {
       CLog::Log(LOGWARNING, "CPlexAES::encrypt failed to encrypt data...");
       return "";
     }
-    
-    outData.append((char*)buffer, 16);
+
+    outData.append((const char*)buffer, chunk.length());
   }
 
   return outData;
@@ -49,23 +52,25 @@ std::string CPlexAES::encrypt(const std::string &data)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 std::string CPlexAES::decrypt(const std::string &data)
 {
-  std::vector<std::string> chunks = chunkData(data);
-  
+  if (data.empty()) {
+    return "";
+  }
+
   std::string outData;
-  BOOST_FOREACH(const std::string& chunk, chunks)
+  unsigned char block[16], buffer[16];
+
+  BOOST_FOREACH(const std::string& chunk, chunkData(data))
   {
-    unsigned char buffer[16];
-    memset(buffer, '\0', 16);
-    
-    if (aes_decrypt((const unsigned char*)chunk.c_str(), buffer, &m_decryptCtx) == EXIT_FAILURE)
+    strncpy((char *)&block[0], chunk.c_str(), chunk.length());
+    if (aes_decrypt(block, buffer, &m_decryptCtx) == EXIT_FAILURE)
     {
       CLog::Log(LOGWARNING, "CPlexAES::decrypt failed to decrypt data...");
       return "";
     }
-    
+
     outData.append((const char*)buffer, chunk.length());
   }
-  
+
   return outData;
 }
 
@@ -73,7 +78,7 @@ std::string CPlexAES::decrypt(const std::string &data)
 std::string CPlexAES::decryptFile(const std::string &url)
 {
   XFILE::CFile file;
-  
+
   if (file.Open(url))
   {
     char buffer[4096];
@@ -84,9 +89,10 @@ std::string CPlexAES::decryptFile(const std::string &url)
       if (r < 4096)
         break;
     }
-    
+    file.Close();
+
     return decrypt(Base64::Decode(outData));
   }
-  
+
   return "";
 }

--- a/plex/Utility/PlexAES.cpp
+++ b/plex/Utility/PlexAES.cpp
@@ -13,12 +13,12 @@ std::vector<std::string> CPlexAES::chunkData(const std::string& data)
 
   while (true)
   {
-    std::string chunk = data.substr(i, 16);
+    std::string chunk = data.substr(i, AES_BLOCK_SIZE);
     chunks.push_back(chunk);
-    if (chunk.length() < 16)
+    if (chunk.length() < AES_BLOCK_SIZE)
       break;
 
-    i += 16;
+    i += AES_BLOCK_SIZE;
   }
 
   return chunks;
@@ -31,7 +31,7 @@ std::string CPlexAES::encrypt(const std::string &data)
     return "";
   }
 
-  unsigned char block[16], buffer[16];
+  unsigned char block[AES_BLOCK_SIZE], buffer[AES_BLOCK_SIZE];
   std::string outData;
 
   BOOST_FOREACH(const std::string& chunk, chunkData(data))
@@ -57,7 +57,7 @@ std::string CPlexAES::decrypt(const std::string &data)
   }
 
   std::string outData;
-  unsigned char block[16], buffer[16];
+  unsigned char block[AES_BLOCK_SIZE], buffer[AES_BLOCK_SIZE];
 
   BOOST_FOREACH(const std::string& chunk, chunkData(data))
   {


### PR DESCRIPTION
Due to token corruption in the server cache all server connections where being passed an empty token, causing major client slowdown presumably while the server checked the invalid token.

Correct length of string generated by CPlexAES::encrypt, which was causing token corruption issue.

Use AES_BLOCK_SIZE instead of literal 16

Optimise empty input case for both CPlexAES encrypt and decrupt.

Ensure we pass a valid AES_BLOCK_SIZE size block to CPlexAES encrypt and decrupt to ensure we don't have buffer overruns.

Close file to prevent leak in decryptFile.

Use IsEmpty() instead of empty() since .. CStdString.

Optimise token loop in BuildURL.
