### PR TITLE
Fix aes encryption / decryption

### DIFF
--- a/plex/Utility/PlexAES.cpp
+++ b/plex/Utility/PlexAES.cpp
@@ -9,16 +9,11 @@
 std::vector<std::string> CPlexAES::chunkData(const std::string& data)
 {
   std::vector<std::string> chunks;
-  int i = 0;
 
-  while (true)
+  for (int i = 0, len = data.length(); i < len; i += AES_BLOCK_SIZE)
   {
     std::string chunk = data.substr(i, AES_BLOCK_SIZE);
     chunks.push_back(chunk);
-    if (chunk.length() < AES_BLOCK_SIZE)
-      break;
-
-    i += AES_BLOCK_SIZE;
   }
 
   return chunks;
@@ -30,14 +25,14 @@ std::string CPlexAES::encrypt(const std::string &data)
   if (data.empty())
     return "";
 
-  unsigned char buffer[AES_BLOCK_SIZE];
+  // aes_encrypt expects a full block size for input so ensure its available
+  // by using a temporary buffed "block".
+  unsigned char block[AES_BLOCK_SIZE], buffer[AES_BLOCK_SIZE];
   std::string outData;
-
   BOOST_FOREACH(const std::string& chunk, chunkData(data))
   {
-    memset(buffer, '\0', AES_BLOCK_SIZE);
-
-    if (aes_encrypt((const unsigned char*)chunk.c_str(), buffer, &m_encryptCtx) == EXIT_FAILURE)
+    strncpy((char *)&block[0], chunk.c_str(), AES_BLOCK_SIZE);
+    if (aes_encrypt(block, buffer, &m_encryptCtx) == EXIT_FAILURE)
     {
       CLog::Log(LOGWARNING, "CPlexAES::encrypt failed to encrypt data...");
       return "";
@@ -57,17 +52,14 @@ std::string CPlexAES::decrypt(const std::string &data)
 
   std::string outData;
   unsigned char buffer[AES_BLOCK_SIZE];
-
   BOOST_FOREACH(const std::string& chunk, chunkData(data))
   {
-    memset(buffer, '\0', AES_BLOCK_SIZE);
     if (aes_decrypt((const unsigned char*)chunk.c_str(), buffer, &m_decryptCtx) == EXIT_FAILURE)
     {
       CLog::Log(LOGWARNING, "CPlexAES::decrypt failed to decrypt data...");
       return "";
     }
-
-    outData.append((const char*)buffer, chunk.length());
+    outData.append((const char*)buffer, strnlen((const char*)buffer, AES_BLOCK_SIZE));
   }
 
   return outData;

--- a/plex/Utility/Tests/PlexAES_Tests.cpp
+++ b/plex/Utility/Tests/PlexAES_Tests.cpp
@@ -3,32 +3,40 @@
 
 const char* key = "ff0a27dc-338c-4e8a-9590-0dddb5f0cbfe";
 
-TEST(PlexAES, encryptDecryptSmallStr)
+void
+TestPlexAES(CStdString data)
 {
   CPlexAES aes(key);
-  CStdString encrypted = aes.encrypt("foo");
+  CStdString encrypted = aes.encrypt(data);
+  int expectedLen = data.length();
+  int rem = data.length() % AES_BLOCK_SIZE;
+  if (rem != 0)
+    expectedLen += AES_BLOCK_SIZE - rem;
 
-  EXPECT_STREQ("foo", aes.decrypt(encrypted).c_str());
+  EXPECT_EQ(expectedLen, encrypted.length());
+
+  CStdString decrypted = aes.decrypt(encrypted);
+  EXPECT_STREQ(data.c_str(), decrypted.c_str());
+
+  EXPECT_EQ(strlen(decrypted.c_str()), strlen(data.c_str()));
+}
+
+TEST(PlexAES, encryptDecryptSmallStr)
+{
+  TestPlexAES("foo");
+}
+
+TEST(PlexAES, encryptDecryptEmpty)
+{
+  TestPlexAES("");
 }
 
 TEST(PlexAES, encryptDecryptToken)
 {
-  CPlexAES aes(key);
-  CStdString token("AAABzKSNM6RAFqPxJDuG");
-  CStdString encrypted = aes.encrypt(token);
-
-  EXPECT_EQ(encrypted.length(), 32);
-
-  CStdString decrypted = aes.decrypt(encrypted);
-  EXPECT_STREQ(token, decrypted);
+  TestPlexAES("AAABzKSNM6RAFqPxJDuG");
 }
 
 TEST(PlexAES, encryptALotOfData)
 {
-  CPlexAES aes(key);
-
-  CStdString enc = aes.encrypt(testItem_movie);
-  CStdString dec = aes.decrypt(enc);
-
-  EXPECT_STREQ(testItem_movie, dec.c_str());
+  TestPlexAES(testItem_movie);
 }


### PR DESCRIPTION
The aes encryption / decryption process previously resulted in a string of the wrong length, fix this.

Updated aes tests to ensure they confirm both length and content match.

Fix potential buffer overrun in aes_encrypt call due to being passed a c_str < AES_BLOCK_SIZE in length.

Fix chunkData returning one too many blocks when the data's length was a multiple of AES_BLOCK_SIZE.
