### PR TITLE
Smoother background transition when changing section

### DIFF
--- a/xbmc/guilib/GUIMultiImage.cpp
+++ b/xbmc/guilib/GUIMultiImage.cpp
@@ -191,8 +191,7 @@ bool CGUIMultiImage::OnMessage(CGUIMessage &message)
       m_plexLabels[list->Get(i)->GetPath()] = list->Get(i)->GetLabel();
     }
     
-    m_directoryStatus = UNLOADED;
-    AllocResources();
+    LoadDirectory();
     
     return true;
   }


### PR DESCRIPTION
When section selection is changed on home screen the background image is cleared before transitioning to the new fanart image

This PR leaves the current image intact resulting in a smoother background image transition
