### PR TITLE
Server reachability

### DIFF
--- a/plex/Client/PlexConnection.cpp
+++ b/plex/Client/PlexConnection.cpp
@@ -81,6 +81,9 @@ CPlexConnection::Merge(CPlexConnectionPtr otherConnection)
   if (m_token.IsEmpty() || (!otherConnection->m_token.IsEmpty() && m_token != otherConnection->m_token))
     m_token = otherConnection->m_token;
 
+  if (m_state != CONNECTION_STATE_REACHABLE && otherConnection->m_state == CONNECTION_STATE_REACHABLE)
+    m_state = otherConnection->m_state;
+
   m_refreshed = true;
 }
 

--- a/plex/Client/PlexConnection.cpp
+++ b/plex/Client/PlexConnection.cpp
@@ -74,7 +74,10 @@ void
 CPlexConnection::Merge(CPlexConnectionPtr otherConnection)
 {
   m_url = otherConnection->m_url;
-  m_type |= otherConnection->m_type;
+  if ((otherConnection->m_type & CONNECTION_DISCOVERED) == CONNECTION_DISCOVERED && otherConnection->m_state == CONNECTION_STATE_REACHABLE)
+    m_type = otherConnection->m_type;
+  else if (m_state != CONNECTION_STATE_REACHABLE)
+    m_type |= otherConnection->m_type;
 
   // If we don't have a token or if the otherConnection have a new token, then we
   // need to use that token instead of our own

--- a/plex/Client/PlexNetworkServiceBrowser.cpp
+++ b/plex/Client/PlexNetworkServiceBrowser.cpp
@@ -36,6 +36,10 @@ void CPlexNetworkServiceBrowser::handleServiceArrival(NetworkServicePtr& service
       CPlexConnectionPtr(new CPlexConnection(CPlexConnection::CONNECTION_DISCOVERED, address, port));
   server->AddConnection(conn);
 
+  if (conn->TestReachability(server) == CPlexConnection::CONNECTION_STATE_REACHABLE) {
+    server->SetActiveConnection(conn);
+  }
+
   g_plexApplication.serverManager->UpdateFromDiscovery(server);
 
   if (!server || server->GetUUID().empty())

--- a/plex/Client/PlexServer.cpp
+++ b/plex/Client/PlexServer.cpp
@@ -377,12 +377,18 @@ void CPlexServer::Merge(CPlexServerPtr otherServer)
       {
         mappedConn->Merge(conn);
         found = true;
+        if (!m_activeConnection && otherServer->GetActiveConnection())
+          m_activeConnection = mappedConn;
         break;
       }
     }
 
     if (!found)
+    {
       AddConnection(conn);
+      if (!m_activeConnection && otherServer->GetActiveConnection())
+        m_activeConnection = conn;
+    }
   }
 }
 


### PR DESCRIPTION
When a local server is discovered by multicast it will wait 5s to test reachability resulting in initial requests to PMS to fail on startup
This PR tests server reachability directly on server discovery, merges connection state and promotes it to active connection if appropriate

When a local discovered server is also listed from myplex the server will keep the connection in reachable state even after the client receives a departure multicast when PMS is shutdown
This PR overrides the connection type for local discovered servers to correctly remove the connection when departure multicasts is received
