### PR TITLE
Only refresh fanout when section is selected

### DIFF
--- a/plex/Home/GUIWindowHome.cpp
+++ b/plex/Home/GUIWindowHome.cpp
@@ -161,7 +161,7 @@ bool CGUIWindowHome::OnAction(const CAction &action)
         m_lastSelectedItem = GetCurrentItemName();
         m_lastSelectedSubItem.Empty();
         if (g_plexApplication.timer)
-          g_plexApplication.timer->SetTimeout(200, this);
+          g_plexApplication.timer->RestartTimeout(200, this);
       }
 
       if (action.GetID() == ACTION_SELECT_ITEM && pItem->HasProperty("sectionPath") &&
@@ -379,12 +379,16 @@ bool CGUIWindowHome::OnMessage(CGUIMessage& message)
     {
       UpdateSections();
 
+      SectionsNeedsRefresh();
+
       RestoreSection();
 
       if (m_lastSelectedItem == "Search")
         RefreshSection("global://art/", CPlexSectionFanout::SECTION_TYPE_GLOBAL_FANART);
-      
-      RefreshAllSections(false);
+
+      if (g_plexApplication.timer)
+        g_plexApplication.timer->RestartTimeout(200, this);
+
       g_plexApplication.themeMusicPlayer->playForItem(CFileItem());
       
       break;
@@ -392,7 +396,7 @@ bool CGUIWindowHome::OnMessage(CGUIMessage& message)
 
     case GUI_MSG_PLEX_BEST_SERVER_UPDATED:
     {
-      RefreshAllSections(true);
+      SectionsNeedsRefresh();
       return true;
     }
 
@@ -741,13 +745,21 @@ void CGUIWindowHome::UpdateSections()
     return;
   }
 
-  vector<CGUIListItemPtr>& oldList = control->GetStaticItems();
+  bool listUpdated = false;
+
+  vector<CGUIListItemPtr> oldList;
+  BOOST_FOREACH(CGUIListItemPtr item, control->GetStaticItems())
+  {
+    if (!item->HasProperty("sectionPath") || m_sections.find(item->GetProperty("sectionPath").asString()) != m_sections.end())
+      oldList.push_back(item);
+    else
+      listUpdated = true;
+  }
 
   CFileItemListPtr sections = g_plexApplication.dataLoader->GetAllSections();
   vector<CGUIListItemPtr> newList;
   vector<CGUIListItemPtr> newSections;
 
-  bool listUpdated = false;
   bool haveShared = false;
   bool haveChannels = false;
   bool haveUpdate = false;
@@ -1053,6 +1065,15 @@ void CGUIWindowHome::SectionNeedsRefresh(const CStdString &url)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+void CGUIWindowHome::SectionsNeedsRefresh()
+{
+  BOOST_FOREACH(nameSectionPair p, m_sections)
+  {
+    p.second->m_needsRefresh = true;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 void CGUIWindowHome::OnTimeout()
 {
   if (GetCurrentItemName() == m_lastSelectedItem)
@@ -1189,6 +1210,7 @@ void CGUIWindowHome::RestoreSection()
 
           if (fItem->HasProperty("sectionPath"))
             ShowSection(fItem->GetProperty("sectionPath").asString());
+          return;
         }
       }
       idx++;

--- a/plex/Home/GUIWindowHome.h
+++ b/plex/Home/GUIWindowHome.h
@@ -74,6 +74,7 @@ private:
   bool GetContentTypesFromSection(const CStdString& url, std::vector<int> &types);
   bool GetContentListFromSection(const CStdString& url, int contentType, CFileItemList &list);
   void SectionNeedsRefresh(const CStdString& url);
+  void SectionsNeedsRefresh();
   void OpenItem(CFileItemPtr item);
   bool OnClick(const CGUIMessage& message);
   void OnSectionLoaded(const CGUIMessage& message);

--- a/plex/Home/PlexSectionFanout.cpp
+++ b/plex/Home/PlexSectionFanout.cpp
@@ -17,11 +17,10 @@ using namespace std;
 CPlexSectionFanout::CPlexSectionFanout(const CStdString& url, SectionTypes sectionType,
                                        bool useGlobalSlideshow)
   : m_sectionType(sectionType),
-    m_needsRefresh(false),
+    m_needsRefresh(true),
     m_url(url),
     m_useGlobalSlideshow(useGlobalSlideshow)
 {
-  Refresh();
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -233,8 +232,10 @@ void CPlexSectionFanout::OnJobComplete(unsigned int jobID, bool success, CJob* j
     m_fileLists[type] = newList;
 
     /* Pre-cache stuff */
+#ifndef TARGET_RASPBERRY_PI
     if (type != CONTENT_LIST_FANART)
       g_plexApplication.thumbCacher->Load(*newList);
+#endif
 
   }
 


### PR DESCRIPTION
When the home screen is loaded either at startup or going back from a section/preplay fanout and art data is refreshed for all sections and once more for the selected section

This PR changes this behavior and only refreshes fanout data once a section is selected
