### PR TITLE
Add support for showing shared sections on home screen

### DIFF
--- a/plex/Home/GUIWindowHome.cpp
+++ b/plex/Home/GUIWindowHome.cpp
@@ -685,7 +685,10 @@ CGUIStaticItemPtr CGUIWindowHome::ItemToSection(CFileItemPtr item)
 {
   CGUIStaticItemPtr newItem = CGUIStaticItemPtr(new CGUIStaticItem);
   newItem->SetLabel(item->GetLabel());
-  newItem->SetLabel2(item->GetProperty("serverName").asString());
+  if (item->HasProperty("serverOwner"))
+    newItem->SetLabel2(item->GetProperty("serverOwner").asString());
+  else
+    newItem->SetLabel2(item->GetProperty("serverName").asString());
   newItem->SetProperty("sectionNameCollision", item->GetProperty("sectionNameCollision"));
   newItem->SetProperty("plex", true);
   newItem->SetProperty("sectionPath", item->GetPath());
@@ -760,6 +763,10 @@ void CGUIWindowHome::UpdateSections()
     for (int i = 0; i < sharedSections->Size(); i++)
     {
       CFileItemPtr sectionItem = sharedSections->Get(i);
+      CPlexServerPtr server = g_plexApplication.serverManager->FindByUUID(sectionItem->GetProperty("serverUUID").asString());
+      if (!server) continue;
+      sectionItem->SetProperty("serverOwner", server->GetOwner());
+      sectionItem->SetProperty("sectionNameCollision", "yes");
       sections->Add(sectionItem);
     }
   }

--- a/plex/Home/GUIWindowHome.cpp
+++ b/plex/Home/GUIWindowHome.cpp
@@ -754,6 +754,16 @@ void CGUIWindowHome::UpdateSections()
   bool havePlaylists = false;
   bool havePlayqueues = false;
 
+  if (g_advancedSettings.m_bSharedSectionsOnHome && g_plexApplication.dataLoader->HasSharedSections())
+  {
+    CFileItemListPtr sharedSections = g_plexApplication.dataLoader->GetAllSharedSections();
+    for (int i = 0; i < sharedSections->Size(); i++)
+    {
+      CFileItemPtr sectionItem = sharedSections->Get(i);
+      sections->Add(sectionItem);
+    }
+  }
+
   for (int i = 0; i < oldList.size(); i ++)
   {
     CGUIListItemPtr item = oldList[i];
@@ -875,7 +885,7 @@ void CGUIWindowHome::UpdateSections()
   }
 
 
-  if (g_plexApplication.dataLoader->HasSharedSections() && !haveShared)
+  if (!g_advancedSettings.m_bSharedSectionsOnHome && g_plexApplication.dataLoader->HasSharedSections() && !haveShared)
   {
     CGUIStaticItemPtr item = CGUIStaticItemPtr(new CGUIStaticItem);
     item->SetLabel(g_localizeStrings.Get(44020));

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -367,6 +367,7 @@ void CAdvancedSettings::Initialize()
 
   m_bForceJpegImageFormat = false;
   m_bUseMatroskaTranscodes = true;
+  m_bSharedSectionsOnHome = false;
 
   /* END PLEX */
 
@@ -1163,6 +1164,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
   XMLUtils::GetBoolean(pRootElement, "hidefanouts", m_bHideFanouts);
   XMLUtils::GetBoolean(pRootElement, "forcejpegimageformat", m_bForceJpegImageFormat);
   XMLUtils::GetBoolean(pRootElement, "usematroskatranscode", m_bUseMatroskaTranscodes);
+  XMLUtils::GetBoolean(pRootElement, "sharedsectionsonhome", m_bSharedSectionsOnHome);
   /* END PLEX */
 
   // load in the GUISettings overrides:

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -394,6 +394,7 @@ class CAdvancedSettings
     void SetDirtyRegionsAlgorithm(int algorithm);
     void SetDirtyRegionsNoFlipTimeout(int timeout);
     bool m_bUseMatroskaTranscodes;
+    bool m_bSharedSectionsOnHome;
     /* END PLEX */
 };
 


### PR DESCRIPTION
This PR adds support for showing shared sections on home screen

advancedsettings.xml is used to enable the feature since a disconnected server sections will show up on home screen until a restart, PHT does not keep track of remote server reachability

plexinc/plex-home-theater-public#29 is recommended to minimize requesting of fanout and art data
