### PR TITLE
Forward httpHeaders to media item

### DIFF
--- a/plex/PlexMediaDecisionEngine.cpp
+++ b/plex/PlexMediaDecisionEngine.cpp
@@ -287,6 +287,10 @@ CFileItemPtr CPlexMediaDecisionJob::ResolveIndirect(CFileItemPtr item)
     if (!i || i->m_mediaItems.size() == 0)
       return CFileItemPtr();
 
+    /* check if we got some httpHeaders from indirect item */
+    if (i->HasProperty("httpHeaders"))
+      i->m_mediaItems[0]->SetProperty("httpHeaders", i->GetProperty("httpHeaders"));
+
     item = i->m_mediaItems[0];
   }
 


### PR DESCRIPTION
When MDE resolves media to play it skips the httpHeaders attribute sent by PMS when using indirect resolve.
This PR forwards the httpHeaders property to the media item returned.
